### PR TITLE
Make canonical mappings for sender addresses configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,21 +47,44 @@ verified. For more information, check
 Role Variables
 --------------
 
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
-|                Name                |   Type   |                Description                | Mandatory |              Default                   |
-+====================================+==========+===========================================+===========+========================================+
-| ``postfix_aws_ses_host``           |  string  | Hostname of Amazon SES server.            |     no    | ``email-smtp.eu-west-1.amazonaws.com`` |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
-| ``postfix_aws_ses_port``           | integer  | Port of Amazon SES server.                |     no    |                ``25``                  |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
-| ``postfix_aws_ses_username``       |  string  | Username for SMTP authentication with     |    yes    |                                        |
-|                                    |          | Amazon SES server.                        |           |                                        |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
-| ``postfix_aws_ses_password``       |  string  | Password for SMTP authentication with     |    yes    |                                        |
-|                                    |          | Amazon SES server.                        |           |                                        |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
-| ``postfix_aws_from_email``         |  string  | Default from email.                       |    yes    |                                        |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------+
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+|                Name                   |   Type   |                Description                | Mandatory |              Default                                                    |
++=======================================+==========+===========================================+===========+=========================================================================+
+| ``postfix_aws_ses_host``              |  string  | Hostname of Amazon SES server.            |     no    | ``email-smtp.eu-west-1.amazonaws.com``                                  |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+| ``postfix_aws_ses_port``              | integer  | Port of Amazon SES server.                |     no    |                ``25``                                                   |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+| ``postfix_aws_ses_username``          |  string  | Username for SMTP authentication with     |    yes    |                                                                         |
+|                                       |          | Amazon SES server.                        |           |                                                                         |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+| ``postfix_aws_ses_password``          |  string  | Password for SMTP authentication with     |    yes    |                                                                         |
+|                                       |          | Amazon SES server.                        |           |                                                                         |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+| ``postfix_aws_default_from_email``    |  string  | Default From email address.               |    yes    |                                                                         |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+| ``postfix_aws_sender_canonical_maps`` |  list    | List of canonical mappings for envelope   |     no    | .. code-block:: yaml                                                    |
+|                                       |          | and header sender addresses of the form:  |           |                                                                         |
+|                                       |          |                                           |           |     pattern: "/.+"                                                      |
+|                                       |          | .. code-block:: yaml                      |           |     address: "{{ postfix_aws_default_from_email }}"                     |
+|                                       |          |                                           |           |     comment: Map all sender addresses to the default From email address |
+|                                       |          |     pattern: string                       |           |                                                                         |
+|                                       |          |     address: string                       |           |                                                                         |
+|                                       |          |     comment: string                       |           |                                                                         |
+|                                       |          |                                           |           |                                                                         |
+|                                       |          | where ``pattern`` represents a regular    |           |                                                                         |
+|                                       |          | expression that matches the original      |           |                                                                         |
+|                                       |          | sender address and ``address`` represents |           |                                                                         |
+|                                       |          | the sender address with which to replace  |           |                                                                         |
+|                                       |          | the original one.                         |           |                                                                         |
+|                                       |          | For more information, see `Postfix's      |           |                                                                         |
+|                                       |          | postconf.5 manual page`_.                 |           |                                                                         |
+|                                       |          | The ``comment`` represent an optional     |           |                                                                         |
+|                                       |          | text to put as a comment in the           |           |                                                                         |
+|                                       |          | ``/etc/postfix/sender_canonical`` file.   |           |                                                                         |
++---------------------------------------+----------+-------------------------------------------+-----------+-------------------------------------------------------------------------+
+
+.. _Postfix's postconf.5 manual page:
+  http://www.postfix.org/postconf.5.html#sender_canonical_maps
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,8 @@
 
 postfix_aws_ses_host: email-smtp.eu-west-1.amazonaws.com
 postfix_aws_ses_port: 25
+
+postfix_aws_sender_canonical_maps:
+  - pattern: "/.+"
+    address: "{{ postfix_aws_default_from_email }}"
+    comment: Map all sender addresses to the default From email address

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,14 @@
     that:
       - postfix_aws_ses_username is defined
       - postfix_aws_ses_password is defined
-      - postfix_aws_from_email is defined
+      - postfix_aws_default_from_email is defined
+
+- name: Sanity check of postfix_aws_sender_canonical_maps variable
+  assert:
+    that:
+      - "'pattern' in item"
+      - "'address' in item"
+  with_items: "{{ postfix_aws_sender_canonical_maps }}"
 
 - name: Install Postfix
   package: name=postfix state=present
@@ -64,11 +71,8 @@
     - /etc/postfix/sasl_passwd.db
     - /etc/postfix/sasl_passwd
 
-- name: Set canonical from email address
-  lineinfile:
-    backup: yes
-    create: yes
+- name: Set canonical mappings for sender addresses
+  template:
+    src: etc/postfix/sender_canonical.j2
     dest: /etc/postfix/sender_canonical
-    regexp: ".*{{ postfix_aws_from_email }}"
-    line: "/.+/ {{ postfix_aws_from_email }}"
-    state: present
+    backup: yes

--- a/templates/etc/postfix/sender_canonical.j2
+++ b/templates/etc/postfix/sender_canonical.j2
@@ -1,0 +1,9 @@
+# List of canonical mappings for envelope and header sender addresses
+# {{ ansible_managed }}
+
+{% for map in postfix_aws_sender_canonical_maps %}
+{% if map.comment is defined %}
+# {{ map.comment }}
+{% endif %}
+{{ map.pattern }} {{ map.address }}
+{% endfor %}


### PR DESCRIPTION
Introduce `postfix_aws_sender_canonical_maps` variable.
Rename `postfix_aws_from_email` variable to `postfix_aws_default_from_email` to make it more obvious that it sets the default sender address.